### PR TITLE
Updating remnants of 5.10 to 6.0.0.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-python.pypy
-===========
+``python.pypy``
+===============
 
 A Chocolatey package for PyPy.
 
-**Current version:** 5.10 (Python 2)
+**Current version:** 6.0.0 (Python 2.7.13)
 
 `Chocolatey package link`_.
 

--- a/python.pypy.nuspec
+++ b/python.pypy.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>http://www.pypy.org</projectUrl>
     <iconUrl>https://rawgit.com/kirbyfan64/python.pypy/master/pypy-icon.png</iconUrl>
     <copyright>2003-2018 The PyPy Developers</copyright>
-    <licenseUrl>https://bitbucket.org/pypy/pypy/src/release-pypy2.7-v5.10.0/LICENSE</licenseUrl>
+    <licenseUrl>https://bitbucket.org/pypy/pypy/src/release-pypy2.7-v6.0.0/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://bitbucket.org/pypy/pypy</projectSourceUrl>
     <docsUrl>https://pypy.readthedocs.io/en/latest/</docsUrl>
@@ -20,7 +20,7 @@
     <tags>python pypy jit rpython</tags>
     <summary>PyPy - a fast Python interpreter</summary>
     <description>PyPy is a fast, compliant Python 2.7 interpreter written in Python.</description>
-    <releaseNotes>http://pypy.readthedocs.io/en/latest/release-v5.10.0.html</releaseNotes>
+    <releaseNotes>https://pypy.readthedocs.io/en/latest/release-v6.0.0.html</releaseNotes>
     <dependencies>
       <dependency id="vcredist2008"/>
     </dependencies>

--- a/tools/chocolateyuninstall.ps1
+++ b/tools/chocolateyuninstall.ps1
@@ -1,1 +1,1 @@
-Uninstall-ChocolateyZipPackage 'python.pypy' 'pypy2-v5.10.0-win32.zip'
+Uninstall-ChocolateyZipPackage 'python.pypy' 'pypy2-v6.0.0-win32.zip'


### PR DESCRIPTION
Also using code font for `python.pypy` in README and referencing specific version of Python 2 (2.7.13).

This is towards "fixing" #5.

Some other questions for you @kirbyfan64:

- Why is `vcredist2008` a dependency? (This came up during [review][1] of the [`pypy3`][2] package)
- Could you add me / others as an owner (or similar role) to `python.pypy` on Chocolatey?
- Is there a reason you chose `python.pypy` over `pypy` as the name? I initially submitted `python.pypy3` to Chocolatey and their guidelines (as well as the reviewer) said I must ditch the `.` in the name, so I just went with `pypy3`

[1]: https://chocolatey.org/packages/python.pypy3
[2]: https://chocolatey.org/packages/pypy3