### PR TITLE
Update package version and deal with renames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Chocolatey PyPy
 ---------------
 
-[![AppVeyor CI Build](https://img.shields.io/appveyor/ci/dhermes/chocolatey-pypy3/master.svg?maxAge=3600&label=AppVeyor)](https://ci.appveyor.com/project/dhermes/chocolatey-pypy3/history)
+[![AppVeyor CI Build](https://img.shields.io/appveyor/ci/kirbyfan64/chocolatey-pypy/master.svg?maxAge=3600&label=AppVeyor)](https://ci.appveyor.com/project/kirbyfan64/chocolatey-pypy/history)
 
 This repository contains configuration for the PyPy packages on
 Chocolatey:

--- a/pypy2/README.rst
+++ b/pypy2/README.rst
@@ -1,7 +1,7 @@
 ``python.pypy``
 ===============
 
-A Chocolatey package for PyPy.
+    A Chocolatey package for PyPy.
 
 **Current version:** 6.0.0 (Python 2.7.13)
 

--- a/pypy2/python.pypy.nuspec
+++ b/pypy2/python.pypy.nuspec
@@ -4,12 +4,12 @@
   <metadata>
     <id>python.pypy</id>
     <version>6.0.0</version>
-    <packageSourceUrl>https://github.com/kirbyfan64/python.pypy</packageSourceUrl>
+    <packageSourceUrl>https://github.com/kirbyfan64/chocolatey-pypy</packageSourceUrl>
     <owners>Ryan Gonzalez</owners>
     <title>PyPy</title>
     <authors>The PyPy Developers</authors>
     <projectUrl>http://www.pypy.org</projectUrl>
-    <iconUrl>https://rawgit.com/kirbyfan64/python.pypy/master/pypy-icon.png</iconUrl>
+    <iconUrl>https://rawgit.com/kirbyfan64/chocolatey-pypy/master/pypy-icon.png</iconUrl>
     <copyright>2003-2018 The PyPy Developers</copyright>
     <licenseUrl>https://bitbucket.org/pypy/pypy/src/release-pypy2.7-v6.0.0/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/pypy2/python.pypy.nuspec
+++ b/pypy2/python.pypy.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>python.pypy</id>
-    <version>6.0</version>
+    <version>6.0.0</version>
     <packageSourceUrl>https://github.com/kirbyfan64/python.pypy</packageSourceUrl>
     <owners>Ryan Gonzalez</owners>
     <title>PyPy</title>

--- a/pypy3/README.rst
+++ b/pypy3/README.rst
@@ -3,8 +3,6 @@
 
     A Chocolatey package for PyPy 3.
 
-|appveyor-build|
-
 **Current version:** 6.0.0 (Python 3.5.3)
 
 `Chocolatey package link`_.
@@ -15,7 +13,3 @@ Installing
 **********
 
 ``install.bat`` is a helper for re-installing the package during development.
-
-.. |appveyor-build| image:: https://img.shields.io/appveyor/ci/dhermes/chocolatey-pypy3/master.svg?maxAge=3600&label=AppVeyor
-   :target: https://ci.appveyor.com/project/dhermes/chocolatey-pypy3/history
-   :alt: AppVeyor CI Build

--- a/pypy3/pypy3.nuspec
+++ b/pypy3/pypy3.nuspec
@@ -4,12 +4,12 @@
   <metadata>
     <id>pypy3</id>
     <version>6.0.0</version>
-    <packageSourceUrl>https://github.com/dhermes/chocolatey-pypy3</packageSourceUrl>
+    <packageSourceUrl>https://github.com/kirbyfan64/chocolatey-pypy</packageSourceUrl>
     <owners>Danny Hermes</owners>
     <title>PyPy 3</title>
     <authors>The PyPy Developers</authors>
     <projectUrl>http://www.pypy.org</projectUrl>
-    <iconUrl>https://rawgit.com/dhermes/chocolatey-pypy3/master/pypy-icon.png</iconUrl>
+    <iconUrl>https://rawgit.com/kirbyfan64/chocolatey-pypy/master/pypy-icon.png</iconUrl>
     <copyright>2003-2018 The PyPy Developers</copyright>
     <licenseUrl>https://bitbucket.org/pypy/pypy/src/release-pypy3.5-v6.0.0/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
I noticed this because the badges say "6.0" (for `python.pypy`) and "6.0.0" (for `pypy3`).

Also, I fixed some links that were referring to my `chocolatey-pypy3` repo or to the old name of this repo.